### PR TITLE
Skip element if '//' in reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function (options) {
 
           var src = $asset.attr(attributes.srcAttribute);
 
-          if (src) {
+          if (src && !src.match(/.*(\/\/).*/)) {
             src = url.parse(src).pathname;
 
             var stats = fs.statSync(path.join(options.cwd, src));

--- a/test/example.html
+++ b/test/example.html
@@ -2,4 +2,7 @@
 
 <script src="abc.js"></script>
 <script src="def.js"></script>
+<script src="sub/ghi.js"></script>
+
 <script></script>
+<script src="//mycdn"></script>

--- a/test/sub/ghi.js
+++ b/test/sub/ghi.js
@@ -1,0 +1,1 @@
+console.log('File GHI');


### PR DESCRIPTION
Simple change to check if '//' located in the reference to a file (so that CDN references are skipped).

Test updated to reflect this change.
